### PR TITLE
Added support of empty ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Security - in case of vulnerabilities.
 
 _TBD_
 
+### Changed
+- Added support of empty ranges, allowing you to use the end time exactly the same as the start time. ([#18](../../pull/19)).
+
 ## [0.4.0] 2018-02-16
 
 ### Added

--- a/src/States/FiniteState.php
+++ b/src/States/FiniteState.php
@@ -26,7 +26,7 @@ final class FiniteState extends RangeState
      */
     public function __construct(DateTimeInterface $startDate, DateTimeInterface $endDate)
     {
-        if ($endDate <= $startDate) {
+        if ($endDate < $startDate) {
             throw new DateRangeException('Invalid end date, must be after start');
         }
 

--- a/tests/States/FiniteRangeTest.php
+++ b/tests/States/FiniteRangeTest.php
@@ -78,12 +78,14 @@ final class FiniteRangeTest extends TestCase
 
     /**
      * @test
+     * @depends checkFiniteState
      */
-    public function guardRangeDatesDifference()
+    public function rangeMayBeEmptyWhenEndsExactlyAtStart()
     {
-        $this->expectException(DateRangeException::class);
-        $this->expectExceptionMessage('Invalid end date, must be after start');
-
-        new FiniteState($this->tomorrow, $this->tomorrow);
+        $subject = new FiniteState($this->tomorrow, $this->tomorrow);
+        self::assertTrue($subject->hasStartDate());
+        self::assertTrue($subject->hasEndDate());
+        self::assertSame($this->tomorrow, $subject->getStartDate());
+        self::assertSame($this->tomorrow, $subject->getEndDate());
     }
 }


### PR DESCRIPTION
## Details
Added support of empty ranges, allowing you to use the end time exactly the same as the start time.